### PR TITLE
When description in None puts '' in the baloon instead of 'None'

### DIFF
--- a/plone/formwidget/geolocation/widget.py
+++ b/plone/formwidget/geolocation/widget.py
@@ -55,8 +55,8 @@ class GeolocationWidget(TextWidget):
         if not coordinates:
             return
 
-        title = getattr(self.context, 'title', '')
-        description = getattr(self.context, 'description', '')
+        title = getattr(self.context, 'title', '') or ''
+        description = getattr(self.context, 'description', '') or ''
 
         geo_json = {
             'type': 'FeatureCollection',


### PR DESCRIPTION
Fixes #17 

If description is not compiled safe_unicode transforms None into 'None' and the popup shows it as text.
This pull request replaces None or any other falsy value with ''