### PR TITLE
If description is not compiled safe_unicode transforms None into 'Non…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.2.2 (unreleased)
 ------------------
 
+- Fix popup displaying the string "None" when no description was given.
+  [parruc]
+
 - Add default_location informations to maps-configuration view.
   [bsuttor]
 

--- a/plone/formwidget/geolocation/widget.py
+++ b/plone/formwidget/geolocation/widget.py
@@ -55,8 +55,8 @@ class GeolocationWidget(TextWidget):
         if not coordinates:
             return
 
-        title = getattr(self.context, "title", "")
-        description = getattr(self.context, "description", "")
+        title = getattr(self.context, "title", "") or ""
+        description = getattr(self.context, "description", "") or ""
 
         geo_json = {
             "type": "FeatureCollection",


### PR DESCRIPTION
…e' and the popup shows it as text