### PR TITLE
Remove the height style from the geolocation input widget map.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove the height style from the geolocation input widget map.
+  It is already set by pat-leaflet.
+  [thet]
 
 
 3.0.0 (2022-10-11)

--- a/plone/formwidget/geolocation/geolocation_input.pt
+++ b/plone/formwidget/geolocation/geolocation_input.pt
@@ -5,7 +5,7 @@
       i18n:domain="plone.formwidget.geolocation"
       tal:omit-tag="">
   <div class="geolocation_wrapper edit">
-    <div class="pat-leaflet" style="height:400px" data-geojson="${view/data_geojson}" data-pat-leaflet='${view/map_configuration}'></div>
+    <div class="pat-leaflet" data-geojson="${view/data_geojson}" data-pat-leaflet='${view/map_configuration}'></div>
 
     <div class="form-group">
       <label tal:attributes="for view/id_input_lat" i18n:translate="label_latitude">Latitude</label>


### PR DESCRIPTION
It is already set by pat-leaflet.