### PR TITLE
Fix map when creating content and sanitize initial default values

### DIFF
--- a/.github/workflows/plone-package-test.yml
+++ b/.github/workflows/plone-package-test.yml
@@ -15,15 +15,16 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
         plone:
           - "6.0-latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Plone ${{ matrix.plone }} with Python ${{ matrix.python }}
         id: setup
-        uses: plone/setup-plone@v1.0.0
+        uses: plone/setup-plone@v2.0.0
         with:
           python-version: ${{ matrix.python }}
           plone-version: ${{ matrix.plone }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Fix controlpanel icon.
   [petschki]
 
+- Fix showing map when creating content and sanitize default lat/lng
+  values with or without default initial configuration settings.
+  [petschki]
+
 
 3.0.4 (2023-06-02)
 ------------------

--- a/plone/formwidget/geolocation/tests/test_widget.py
+++ b/plone/formwidget/geolocation/tests/test_widget.py
@@ -97,22 +97,24 @@ class TestWidget(unittest.TestCase):
         coordinates = feature["geometry"]["coordinates"]
         self.assertEqual(coordinates, [5.0, 50.0])
 
-    def test_default_loc(self):
+    def test_default_location(self):
         widget = GeolocationWidget(self.request)
         widget.id = widget.name = "geolocation"
         widget.request[widget.name] = None
 
         widget.update()
-        self.assertEqual(widget._default_loc(), (None, None))
+        self.assertEqual(widget.value, (None, None))
+        self.assertEqual(widget.coordinates, ("0", "0"))
 
         set_registry_record("geolocation.default_latitude", 70.0)
         set_registry_record("geolocation.default_longitude", 7.0)
         widget.update()
-        self.assertEqual(widget._default_loc(), (70.0, 7.0))
+        self.assertEqual(widget.value, (70.0, 7.0))
+        self.assertEqual(widget.coordinates, (70.0, 7.0))
 
         set_registry_record("geolocation.use_default_geolocation_as_value", False)
         widget.update()
-        self.assertEqual(widget._default_loc(), (None, None))
+        self.assertEqual(widget.value, (None, None))
 
     def test_render(self):
         widget = GeolocationWidget(self.request)

--- a/plone/formwidget/geolocation/widget.py
+++ b/plone/formwidget/geolocation/widget.py
@@ -111,7 +111,7 @@ class GeolocationWidget(TextWidget):
             # and self.coordinates (map marker)
             self.value = self.coordinates = (
                 getrec("geolocation.default_latitude"),
-                getrec("geolocation.default_longitude")
+                getrec("geolocation.default_longitude"),
             )
 
         if self.coordinates is None or not all(self.coordinates):

--- a/plone/formwidget/geolocation/widget.py
+++ b/plone/formwidget/geolocation/widget.py
@@ -110,19 +110,19 @@ class GeolocationWidget(TextWidget):
             # the values are injected to self.value (input fields)
             # and self.coordinates (map marker)
             self.value = self.coordinates = (
-                getrec("geolocation.default_latitude", default="0") or "0",
-                getrec("geolocation.default_longitude", default="0") or "0",
+                getrec("geolocation.default_latitude"),
+                getrec("geolocation.default_longitude")
             )
 
-        if self.mode == "input":
-            # fallback to ("0", "0") for input mode to show the map and the marker
-            self.coordinates = ("0", "0")
-
-        # no default value for contents not yet geolocated
-        # the display template will not show the map at all
-        # NOTE: when creating a content, self.value is None so we have to
-        # set the initial lat/lng tuple here
-        self.value = (None, None)
+        if self.coordinates is None or not all(self.coordinates):
+            # no default value for contents not yet geolocated
+            # the display template will not show the map at all
+            # NOTE: when creating a content, self.value is None so we have to
+            # set the initial lat/lng tuple here
+            self.value = (None, None)
+            if self.mode == "input":
+                # fallback to ("0", "0") for input mode to show the map and the marker
+                self.coordinates = ("0", "0")
 
 
 @implementer(IFieldWidget)


### PR DESCRIPTION
This is another fix for default lat/lng values. Right now, there's a JS error when creating a content with geolocation behavior enabled, because the map configuration gets lat/lng = (null, null). I have refactored this:

1. split the internals into `self.value` and `self.coordinates` to make it possible to show an initial map marker but leave the input fields empty when someone doesn't want to geolocate at all.
2. inject default values correctly if it is enabled in the settings.

Caveats:

- If you have entered a value in lat/lng and want to try to remove it, Leaflet always fills with "0" ... this must be a javascript event somewhere.
- If you move the marker, the input fields get filled and you cannot empty it again ... see above.

Because this fixes the bug of not showing the map at all when creating a content I'd like to merge this, before fixing the caveats.