### PR TITLE
Bundles switch while upgrading from 2.2.X to 3.0.X

### DIFF
--- a/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
+++ b/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
@@ -4,4 +4,17 @@
            prefix="plone.bundles/bundle-leaflet"
            remove="true"
   />
+  <records interface="plone.formwidget.geolocation.interfaces.IGeolocationSettings"
+           prefix="geolocation"
+  />
+  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+           prefix="plone.bundles/plone-formwidget-geolocation"
+  >
+    <value key="depends" />
+    <value key="load_async">False</value>
+    <value key="load_defer">False</value>
+    <value key="enabled">True</value>
+    <value key="jscompilation">++plone++plone.formwidget.geolocation/bundle-remote.min.js</value>
+    <value key="csscompilation" />
+  </records>
 </registry>

--- a/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
+++ b/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
@@ -7,7 +7,7 @@
   <records interface="plone.formwidget.geolocation.interfaces.IGeolocationSettings"
            prefix="geolocation"
   />
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="Products.CMFPlone.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/plone-formwidget-geolocation"
   >
     <value key="depends" />

--- a/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
+++ b/plone/formwidget/geolocation/profiles/upgrades/to_2000/registry.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <registry>
-  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+  <records interface="Products.CMFPlone.interfaces.resources.IBundleRegistry"
            prefix="plone.bundles/bundle-leaflet"
            remove="true"
   />


### PR DESCRIPTION
Upgrading removes the patternslib bundle but does not add the new bundle.